### PR TITLE
include module in route if applicable

### DIFF
--- a/YiiNewRelic.php
+++ b/YiiNewRelic.php
@@ -156,9 +156,9 @@ class YiiNewRelic extends CApplicationComponent
 	public function setTransactionName($controllerId, $actionId) {
 		$route = $controllerId . '/' . $actionId;
 		$module = Yii::app()->controller->module;
-		if (is_object($module) && property_exists($module, 'id')) {
-			$route = $module->id . '/' . $route;
-		}
+		if ($module instanceof CModule)
+			$route = $module->getId() . '/' . $route;
+
 		$this->nameTransaction($route);
 	}
 


### PR DESCRIPTION
So, I would not get to see the module in the transaction. Here's the fix to get it done.

FYI:
The property_exists prevents the route from including the module if module exists. CWebModule would be the first approach, but hence messing up with the framework is very common the safest bet is CModule. If CModule instance is returned then it is dead certain that getId() exists and thus is safe to use.